### PR TITLE
Persisting replica connections

### DIFF
--- a/activerecord_autoreplica.gemspec
+++ b/activerecord_autoreplica.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "activerecord_autoreplica"
-  s.version = "1.1.0"
+  s.version = "1.1.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]


### PR DESCRIPTION
- Memoize our custom `ConnectionHandler`
- Prefer `release_connection` after swapping `ActiveRecord::Base.connection_handler` to its original handler instead of `disconnect_read_pool!`
- Make `resolve_connection_url` private as per TODO note
- Bump version to 1.1.1

Closes #2 